### PR TITLE
fix: handle null instead of try-catch

### DIFF
--- a/android/src/main/java/com/visioncamerapluginbarcodescanner/VisionCameraPluginBarcodeScanner.java
+++ b/android/src/main/java/com/visioncamerapluginbarcodescanner/VisionCameraPluginBarcodeScanner.java
@@ -82,8 +82,10 @@ public class VisionCameraPluginBarcodeScanner extends FrameProcessorPlugin {
       if (mediaImage != null) {
         InputImage image = InputImage.fromMediaImage(mediaImage, imageProxy.getImageInfo().getRotationDegrees());
         Barcode barcodeResults = getScannerResults(image, scannerClient);
-        WritableNativeMap barcodeData = mapBarcodeData(barcodeResults);
-        return barcodeData;
+        if (barcodeResults != null) {
+          return mapBarcodeData(barcodeResults);
+        }
+        return null;
       }
       return null;
     } catch (Exception e) {


### PR DESCRIPTION
Found in debugging something - that we fall into the try-catch very often due to having a null result set returned. Seems saner to just handle null and return it vs an NPE that is caught.